### PR TITLE
robust solver updates (#384)

### DIFF
--- a/cubical/DefaultParset.cfg
+++ b/cubical/DefaultParset.cfg
@@ -416,20 +416,29 @@ diag-only    = 0                # Use only diagonal (parallel-hand) data and mod
                                   #type:bool
 offdiag-only = 0                # Use only off-diagonal data and model terms for the solution, and only solve
                                   for off-diagonal Jones elements, pinning the on-diagonals to 1. #type:bool
-robust-cov = compute             # Determines how the residuals covariance matrix is computed if the robust-2x2
+robust-cov = compute            # Determines how the residuals covariance matrix is computed if the robust-2x2
                                   solver is selected. Options are 'compute' to compute normaly, 'identity' to set the
                                   covariance to 1 (identity matrix) as in the Robust-t paper, and 'hybrid' which is the default computes
                                   the covaraince matrix, C but sets it to 1 if the elements are greater than 1.
                                   #options:compute|identity|hybrid
-robust-scale = 1            # Scales down the residuals covariance matrix. Simulations show that this improves the results
+robust-scale = 0                # Scales down the residuals covariance matrix by this factor. Simulations show that this improves the results
                                   with unmodelled sources. This might because of how to correctly computed the normalisation
                                   factor for computing the covariance matrix.
-                                  #type:bool
+                                  #type:int
 robust-npol = 2                 # The number of correlations (polarizations) actually present in the visibilities.
                                   This option only applies if the robust-2x2 solver is selected. Expecting 2 or 4 correlations
                                 #type:float
-robust-int =  1                 # Number of iterations after which the v-parameter is recomputed for the robust solver
+robust-int =  1                 # Number of iterations after which the v-parameter and the covariance matrice are recomputed for the robust solver
                                 #type:int
+
+robust-flag-weights = 0         # run a dummy iteration with the robust solver and flag the data bsaed on the weights
+                                #type:bool
+
+robust-cov-thresh = 1           # An estimated Covariance higher than this threshold indicates significant RFI in the data
+                                # Hence the v-parameter will be set to 2 and covariance to the identity matrix 
+                                #type:float
+robust-sigma-thresh = 3         # Number of sigma thresholds to use when flagging with the weights from the robust solver
+                                     
 robust-save-weights = 0         # Determines if the appied weights from the robust-2x2 solver are stored.
                                   This option only applies if the robust-2x2 solver is selected. If this option is set
                                   and output-weight-column must be set as well.
@@ -442,7 +451,7 @@ _Templated  = 1
 dd-term     = 0                 # Determines whether this term is direction dependent. --model-ddes must
 time-int    = 1                 # Time solution interval for this term. 0 means use entire chunk. #metavar:TIMESLOTS
 freq-int    = 1                 # Frequency solution interval for this term. 0 means use entire chunk. #metavar:CHANNELS
-clip-low    = .1                # Amplitude clipping - flag solutions with diagonal amplitudes below this
+clip-low    =.1                # Amplitude clipping - flag solutions with diagonal amplitudes below this
                                   value. #metavar:AMPL #type:float
 clip-high   = 10                # Amplitude clipping - flag solutions with any amplitudes above this value.
                                   #metavar:AMPL #type:float

--- a/cubical/kernels/diag_robust.py
+++ b/cubical/kernels/diag_robust.py
@@ -1,0 +1,487 @@
+# CubiCal: a radio interferometric calibration suite
+# (c) 2017 Rhodes University & Jonathan S. Kenyon
+# http://github.com/ratt-ru/CubiCal
+# This code is distributed under the terms of GPLv2, see LICENSE.md for details
+"""
+Kernels for 2x2 complex visibilities with diagonal gains. Functions require output arrays to be 
+provided. Common dimensions of arrays are:
+
++----------------+------+
+| Dimension      | Size |
++================+======+
+| Direction      |   d  |
++----------------+------+
+| Model          |   m  |
++----------------+------+
+| Time           |   t  |
++----------------+------+
+| Time Intervals |   ti |
++----------------+------+
+| Frequency      |   f  |
++----------------+------+
+| Freq Intervals |   fi |
++----------------+------+
+| Antenna        |   a  |
++----------------+------+
+| Correlation    |   c  |
++----------------+------+
+
+"""
+from builtins import range
+
+import numpy as np
+from numba import jit, prange
+
+import cubical.kernels
+from cubical.kernels import generics
+from cubical.kernels import full_complex
+from cubical.kernels import full_W_complex
+
+use_parallel = True if cubical.kernels.num_omp_threads > 1 else False
+use_cache = cubical.kernels.use_cache
+
+# Allocators same as for generic full kernel
+allocate_vis_array = full_complex.allocate_vis_array
+allocate_gain_array = full_complex.allocate_gain_array
+allocate_flag_array = full_complex.allocate_flag_array
+allocate_param_array = full_complex.allocate_param_array
+
+@jit(nopython=True, fastmath=True, parallel=use_parallel, cache=use_cache, nogil=True)
+def compute_residual(m, g, gh, r, t_int, f_int):
+    """
+    Given the model, gains, and their conjugates, computes the residual. Residual has full time and
+    frequency resolution - solution intervals are used to correctly associate the gains with the
+    model.
+
+    Args:
+        m (np.complex64 or np.complex128):
+            Typed memoryview of model array with dimensions (d, m, t, f, a, a, c, c).
+        g (np.complex64 or np.complex128):
+            Typed memoryview of gain array with dimension (d, ti, fi, a, c, c).
+        gh (np.complex64 or np.complex128):
+            Typed memoryview of conjugate gain array with dimensions (d, ti, fi, a, c, c).
+        r (np.complex64 or np.complex128):
+            Typed memoryview of residual array with dimensions (m, t, f, a, a, c, c).
+        t_int (int):
+            Number of time slots per solution interval.
+        f_int (int):
+            Number of frequencies per solution interval.
+    """
+    n_dir = m.shape[0]
+    n_mod = m.shape[1]
+    n_tim = m.shape[2]
+    n_fre = m.shape[3]
+    n_ant = m.shape[4]
+    g_dir = g.shape[0]
+
+    bls = np.array([[i,j] for i in range(n_ant) for j in range(i+1, n_ant)], dtype=np.int32)
+    n_bl = bls.shape[0]
+
+    broadcast_times = np.array([t//t_int for t in range(n_tim)])
+    broadcast_freqs = np.array([f//f_int for f in range(n_fre)])
+    broadcast_dirs = np.array([d%g_dir for d in range(n_dir)])
+
+    for ibl in prange(n_bl):
+        aa, ab = bls[ibl][0], bls[ibl][1]  
+        for i in range(n_mod):
+            for t in range(n_tim):
+                bt = broadcast_times[t]
+                for f in range(n_fre):
+                    bf = broadcast_freqs[f]
+                    for d in range(n_dir):
+                        bd = broadcast_dirs[d]
+                    
+                        g00 = g[bd,bt,bf,aa,0,0]
+                        g11 = g[bd,bt,bf,aa,1,1]
+
+                        m00 = m[d,i,t,f,aa,ab,0,0]
+                        m01 = m[d,i,t,f,aa,ab,0,1]
+                        m10 = m[d,i,t,f,aa,ab,1,0]
+                        m11 = m[d,i,t,f,aa,ab,1,1]
+
+                        gh00 = gh[bd,bt,bf,ab,0,0]
+                        gh11 = gh[bd,bt,bf,ab,1,1]
+
+                        r[i,t,f,aa,ab,0,0] -= g00*m00*gh00
+                        r[i,t,f,aa,ab,0,1] -= g00*m01*gh11
+                        r[i,t,f,aa,ab,1,0] -= g11*m10*gh00
+                        r[i,t,f,aa,ab,1,1] -= g11*m11*gh11
+
+                    r[i,t,f,ab,aa,0,0] = r[i,t,f,aa,ab,0,0].conjugate()
+                    r[i,t,f,ab,aa,1,0] = r[i,t,f,aa,ab,0,1].conjugate()
+                    r[i,t,f,ab,aa,0,1] = r[i,t,f,aa,ab,1,0].conjugate()
+                    r[i,t,f,ab,aa,1,1] = r[i,t,f,aa,ab,1,1].conjugate()
+
+
+@jit(nopython=True, fastmath=True, parallel=use_parallel, cache=use_cache, nogil=True)
+def compute_jh(m, g, jh, t_int, f_int):
+    """
+    Given the model and gains, computes the non-zero elements of J\ :sup:`H`. J\ :sup:`H` has full
+    time and frequency resolution - solution intervals are used to correctly associate the gains
+    with the model. The result here contains the useful elements of J\ :sup:`H` but does not look
+    like the analytic solution.
+
+    Args:
+        m (np.complex64 or np.complex128):
+            Typed memoryview of model array with dimensions (d, m, t, f, a, a, c, c).
+        g (np.complex64 or np.complex128):
+            Typed memoryview of gain array with dimension (d, ti, fi, a, c, c).
+        jh (np.complex64 or np.complex128):
+            Typed memoryview of J\ :sup:`H` array with dimensions (d, m, t, f, a, a, c, c).
+        t_int (int):
+            Number of time slots per solution interval.
+        f_int (int):
+            Number of frequencies per solution interval.
+    """
+    n_dir = m.shape[0]
+    n_mod = m.shape[1]
+    n_tim = m.shape[2]
+    n_fre = m.shape[3]
+    n_ant = m.shape[4]
+
+    g_dir = g.shape[0]
+
+    all_bls = np.array([[i,j] for i in range(n_ant) for j in range(n_ant) if i!=j])
+    n_bl = all_bls.shape[0]
+
+    broadcast_times = np.array([t//t_int for t in range(n_tim)])
+    broadcast_freqs = np.array([f//f_int for f in range(n_fre)])
+    broadcast_dirs = np.array([d%g_dir for d in range(n_dir)])
+
+    for ibl in prange(n_bl):
+        aa, ab = all_bls[ibl,0], all_bls[ibl,1]
+        for i in range(n_mod):
+            for t in range(n_tim):
+                bt = broadcast_times[t]
+                for f in range(n_fre):
+                    bf = broadcast_freqs[f]
+                    for d in range(n_dir):
+                        bd = broadcast_dirs[d]
+
+                        g00 = g[bd,bt,bf,aa,0,0]
+                        g11 = g[bd,bt,bf,aa,1,1]
+
+                        m00 = m[d,i,t,f,aa,ab,0,0]
+                        m01 = m[d,i,t,f,aa,ab,0,1]
+                        m10 = m[d,i,t,f,aa,ab,1,0]
+                        m11 = m[d,i,t,f,aa,ab,1,1]
+                        
+                        jh[d,i,t,f,aa,ab,0,0] = g00*m00
+                        jh[d,i,t,f,aa,ab,0,1] = g00*m01
+                        jh[d,i,t,f,aa,ab,1,0] = g11*m10
+                        jh[d,i,t,f,aa,ab,1,1] = g11*m11
+
+@jit(nopython=True, fastmath=True, parallel=use_parallel, cache=use_cache, nogil=True)
+def compute_update(jhr, jhjinv, upd):
+    """
+    Given J\ :sup:`H`\R and (J\ :sup:`H`\J)\ :sup:`-1`, computes the gain update. The dimensions of
+    the input should already be consistent, making this operation simple.
+
+    Args:
+        jhr (np.complex64 or np.complex128):
+            Typed memoryview of J\ :sup:`H`\R array with dimensions (d, ti, fi, a, c, c).
+        jhjinv (np.complex64 or np.complex128):
+            Typed memoryview of (J\ :sup:`H`\J)\ :sup:`-1` array with dimensions
+            (d, ti, fi, a, c, c).
+        upd (np.complex64 or np.complex128):
+            Typed memoryview of gain update array with dimensions (d, ti, fi, a, c, c).
+    """
+
+    n_dir = jhr.shape[0]
+    n_tim = jhr.shape[1]
+    n_fre = jhr.shape[2]
+    n_ant = jhr.shape[3]
+
+    for aa in prange(n_ant):
+        for t in range(n_tim):
+            for f in range(n_fre):
+                for d in range(n_dir):
+
+                    jhr00 = jhr[d,t,f,aa,0,0]
+                    jhr01 = jhr[d,t,f,aa,0,1]
+                    jhr10 = jhr[d,t,f,aa,1,0]
+                    jhr11 = jhr[d,t,f,aa,1,1]
+
+                    jhjinv00 = jhjinv[d,t,f,aa,0,0]
+                    jhjinv01 = jhjinv[d,t,f,aa,0,1]
+                    jhjinv10 = jhjinv[d,t,f,aa,1,0]
+                    jhjinv11 = jhjinv[d,t,f,aa,1,1]
+                    
+                    upd[d,t,f,aa,0,0] = (jhr00*jhjinv00 + jhr01*jhjinv10) 
+                    upd[d,t,f,aa,0,1] = 0
+                    upd[d,t,f,aa,1,0] = 0
+                    upd[d,t,f,aa,1,1] = (jhr10*jhjinv01 + jhr11*jhjinv11)
+
+@jit(nopython=True, fastmath=True, parallel=use_parallel, cache=use_cache, nogil=True)
+def compute_corrected(o, g, gh, corr, t_int, f_int):
+    """
+    Given the observed visbilities, inverse gains, and their conjugates, computes the corrected
+    visibilitites.
+
+    Args:
+        o (np.complex64 or np.complex128):
+            Typed memoryview of observed visibility array with dimensions (t, f, a, a, c, c).
+        g (np.complex64 or np.complex128):
+            Typed memoryview of inverse gain array with dimensions (d, ti, fi, a, c, c).
+        gh (np.complex64 or np.complex128):
+            Typed memoryview of inverse conjugate gain array with dimensions (d, ti, fi, a, c, c).
+        corr (np.complex64 or np.complex128):
+            Typed memoryview of corrected data array with dimensions (t, f, a, a, c, c).
+        t_int (int):
+            Number of time slots per solution interval.
+        f_int (int):
+            Number of frequencies per solution interval.
+    """
+
+    n_dir = g.shape[0]
+    n_tim = o.shape[0]
+    n_fre = o.shape[1]
+    n_ant = o.shape[2]
+
+    bls = np.array([[i,j] for i in range(n_ant) for j in range(i+1, n_ant)], dtype=np.int32)
+    n_bl = bls.shape[0]
+
+    broadcast_times = np.array([t//t_int for t in range(n_tim)])
+    broadcast_freqs = np.array([f//f_int for f in range(n_fre)])
+
+    for ibl in prange(n_bl):
+        aa, ab = bls[ibl][0], bls[ibl][1]
+        for t in range(n_tim):
+            bt = broadcast_times[t]
+            for f in range(n_fre):
+                bf = broadcast_freqs[f]
+
+                g00 = g[0,bt,bf,aa,0,0]
+                g11 = g[0,bt,bf,aa,1,1]
+
+                o00 = o[t,f,aa,ab,0,0]
+                o01 = o[t,f,aa,ab,0,1]
+                o10 = o[t,f,aa,ab,1,0]
+                o11 = o[t,f,aa,ab,1,1]
+
+                gh00 = gh[0,bt,bf,ab,0,0]
+                gh11 = gh[0,bt,bf,ab,1,1]
+
+                corr[t,f,aa,ab,0,0] = g00*o00*gh00
+                corr[t,f,aa,ab,0,1] = g00*o01*gh11
+                corr[t,f,aa,ab,1,0] = g11*o10*gh00
+                corr[t,f,aa,ab,1,1] = g11*o11*gh11
+
+                corr[t,f,ab,aa,0,0] = corr[t,f,aa,ab,0,0].conjugate()
+                corr[t,f,ab,aa,1,0] = corr[t,f,aa,ab,0,1].conjugate()
+                corr[t,f,ab,aa,0,1] = corr[t,f,aa,ab,1,0].conjugate()
+                corr[t,f,ab,aa,1,1] = corr[t,f,aa,ab,1,1].conjugate()
+
+@jit(nopython=True, fastmath=True, parallel=use_parallel, cache=use_cache, nogil=True)
+def compute_weights(r, ic, w, v, npol):
+    """
+    This function updates the weights, using the expression: 
+        w[i] = (v+2*npol)/(v + 2*r[i].T.cov.r[i])
+
+    Args:
+        r (np.complex64 or np.complex128):
+            Typed memoryview of residual array with dimensions (m, t, f, a, a, c, c).
+        ic (np.complex64 or np.complex128):
+            Typed memoryview of inverse covariance array with dimensions (4,4).
+        w (np.complex64 or np.complex128):
+            Typed memoryview of weight array with dimensions (m, t, f, a, a, 1).
+        v (float):
+            Degrees of freedom of the t-distribution.
+        npol (float):
+            Number of polarizations (correlations) in use.            
+    """
+    n_mod = r.shape[0]
+    n_tim = r.shape[1]
+    n_fre = r.shape[2]
+    n_ant = r.shape[3]
+
+    all_bls = np.array([[i,j] for i in range(n_ant) for j in range(n_ant) if i!=j], dtype=np.int32)
+    n_bl = all_bls.shape[0]
+    
+    for ibl in prange(n_bl):
+        aa, ab = all_bls[ibl][0], all_bls[ibl][1]
+        for i in range(n_mod):
+            for t in range(n_tim):
+                for f in range(n_fre):
+
+                    r00 = r[i,t,f,aa,ab,0,0]
+                    r11 = r[i,t,f,aa,ab,1,1]
+
+                    rc00 = r[i,t,f,aa,ab,0,0].conjugate()
+                    rc11 = r[i,t,f,aa,ab,1,1].conjugate()
+
+                    denom = rc00*ic[0,0]*r00 + rc11*ic[3,3]*r11
+
+                    w[i,t,f,aa,ab,0] = (v + npol)/(v + denom.real) # using LB derivation
+
+@jit(nopython=True, fastmath=True, parallel=use_parallel, cache=use_cache, nogil=True)
+def compute_cov(r, ic, w):
+    """
+    This function computes the un-normlaised weighted covariance matrix of 
+    the visibilities using the expression: 
+        cov = r.conj()*w.r
+    
+    Args:
+        r (np.complex64 or np.complex128):
+            Typed memoryview of residual array with dimensions (m, t, f, a, a, c, c).
+        ic (np.complex64 or np.complex128):
+            Typed memoryview of weighted inverse covariance array with dimensions (4,4).
+        w (np.complex64 or np.complex128):
+            Typed memoryview of weight array with dimensions (m, t, f, a, a, 1).         
+    """    
+    n_mod = r.shape[0]
+    n_tim = r.shape[1]
+    n_fre = r.shape[2]
+    n_ant = r.shape[3]
+
+    bls = np.array([[i,j] for i in range(n_ant) for j in range(i+1, n_ant)], dtype=np.int32)
+    n_bl = bls.shape[0]
+    
+    for ibl in prange(n_bl):
+        aa, ab = bls[ibl][0], bls[ibl][1]  
+        for i in range(n_mod):
+            for t in range(n_tim):
+                for f in range(n_fre):
+
+                    r00 = r[i,t,f,aa,ab,0,0]
+                    r11 = r[i,t,f,aa,ab,1,1]
+
+                    rc00 = r[i,t,f,aa,ab,0,0].conjugate()
+                    rc11 = r[i,t,f,aa,ab,1,1].conjugate()
+
+                    w0 = w[i,t,f,aa,ab,0].real
+
+                    w0r00 = w0*r00
+                    w0r11 = w0*r11
+
+                    ic[0,0] += rc00*w0r00
+                    ic[3,3] += rc11*w0r11 
+
+@jit(nopython=True, fastmath=True, parallel=use_parallel, cache=use_cache, nogil=True)
+def apply_gains(m, g, gh, t_int, f_int):
+    """
+    Applies the gains and their conjugates to the model array. This operation is performed in place
+    - be wary of losing the original array. The result has full time and frequency resolution -
+    solution intervals are used to correctly associate the gains with the model.
+
+    Args:
+        m (np.complex64 or np.complex128):
+            Typed memoryview of model visibility array with dimensions (d, m , t, f, a, a, c, c).
+        g (np.complex64 or np.complex128):
+            Typed memoryview of gain array with dimensions (d, ti, fi, a, c, c).
+        gh (np.complex64 or np.complex128):
+            Typed memoryview of conjugate gain array with dimensions (d, ti, fi, a, c, c).
+        t_int (int):
+            Number of time slots per solution interval.
+        f_int (int):
+            Number of frequencies per solution interval.
+    """
+
+    n_dir = m.shape[0]
+    n_mod = m.shape[1]
+    n_tim = m.shape[2]
+    n_fre = m.shape[3]
+    n_ant = m.shape[4]
+
+    g_dir = g.shape[0]
+
+    bls = np.array([[i,j] for i in range(n_ant) for j in range(i+1, n_ant)], dtype=np.int32)
+    n_bl = bls.shape[0]
+
+    broadcast_times = np.array([t//t_int for t in range(n_tim)])
+    broadcast_freqs = np.array([f//f_int for f in range(n_fre)])
+    broadcast_dirs = np.array([d%g_dir for d in range(n_dir)])
+
+    for ibl in prange(n_bl):
+        aa, ab = bls[ibl][0], bls[ibl][1]  
+        for i in range(n_mod):
+            for t in range(n_tim):
+                bt = broadcast_times[t]
+                for f in range(n_fre):
+                    bf = broadcast_freqs[f]
+                    for d in range(n_dir):
+                        bd = broadcast_dirs[d]
+                        
+                        g00 = g[bd,bt,bf,aa,0,0]
+                        g11 = g[bd,bt,bf,aa,1,1]
+
+                        m00 = m[d,i,t,f,aa,ab,0,0]
+                        m01 = m[d,i,t,f,aa,ab,0,1]
+                        m10 = m[d,i,t,f,aa,ab,1,0]
+                        m11 = m[d,i,t,f,aa,ab,1,1]
+
+                        gh00 = gh[bd,bt,bf,ab,0,0]
+                        gh11 = gh[bd,bt,bf,ab,1,1]
+
+                        m[d,i,t,f,aa,ab,0,0] = g00*m00*gh00
+                        m[d,i,t,f,aa,ab,0,1] = g00*m01*gh11
+                        m[d,i,t,f,aa,ab,1,0] = g11*m10*gh00
+                        m[d,i,t,f,aa,ab,1,1] = g11*m11*gh11
+
+                        m[d,i,t,f,ab,aa,0,0] = m[d,i,t,f,aa,ab,0,0].conjugate()
+                        m[d,i,t,f,ab,aa,1,0] = m[d,i,t,f,aa,ab,0,1].conjugate()
+                        m[d,i,t,f,ab,aa,0,1] = m[d,i,t,f,aa,ab,1,0].conjugate()
+                        m[d,i,t,f,ab,aa,1,1] = m[d,i,t,f,aa,ab,1,1].conjugate()
+
+@jit(nopython=True, fastmath=True, parallel=use_parallel, cache=use_cache, nogil=True)
+def right_multiply_gains(g, g_next, t_int, f_int):
+    """
+    Multiples two gain terms in place. Result has full time and frequency resolution 
+    even if g_next does does not. For use in Jones chain.
+
+    NOTE: THIS MAY BE INCORRECT/BACKWARDS.
+
+    Args:
+        g (np.complex64 or np.complex128):
+            Typed memoryview of gain array with dimensions (d, t, f, a, c, c).
+        g_next (np.complex64 or np.complex128):
+            Typed memoryview of gain array with dimensions (d, ti, fi, a, c, c).
+        t_int (int):
+            Number of time slots per solution interval.
+        f_int (int):
+            Number of frequencies per solution interval.
+    """
+
+    n_dir = g.shape[0]
+    n_tim = g.shape[1]
+    n_fre = g.shape[2]
+    n_ant = g.shape[3]
+
+    g_dir = g_next.shape[0]
+
+    broadcast_times = np.array([t//t_int for t in range(n_tim)])
+    broadcast_freqs = np.array([f//f_int for f in range(n_fre)])
+    broadcast_dirs = np.array([d%g_dir for d in range(n_dir)])
+
+    for aa in prange(n_ant):
+        for t in range(n_tim):
+            bt = broadcast_times[t]
+            for f in range(n_fre):
+                bf = broadcast_freqs[f]
+                for d in range(n_dir):
+                    bd = broadcast_dirs[d]
+
+                    g00 = g[d,t,f,aa,0,0]
+                    g11 = g[d,t,f,aa,1,1]
+
+                    g_next00 = g_next[bd,bt,bf,aa,0,0]
+                    g_next01 = g_next[bd,bt,bf,aa,0,1]
+                    g_next10 = g_next[bd,bt,bf,aa,1,0]
+                    g_next11 = g_next[bd,bt,bf,aa,1,1]
+
+                    g[d,t,f,aa,0,0] *= g_next00
+                    g[d,t,f,aa,0,1] *= g_next11
+                    g[d,t,f,aa,1,0] *= g_next00
+                    g[d,t,f,aa,1,1] *= g_next11
+
+# Map compute_jhr method to a generic complex case.
+compute_jhwr = full_W_complex.compute_jhwr
+
+# Map compute_jhj method to a generic complex case.
+compute_jhwj = full_W_complex.compute_jhwj
+
+# Map the J^H.J inversion method to a generic inversion.
+compute_jhjinv = generics.compute_2x2_inverse
+
+# Map inversion to generic diagonal inverse.
+invert_gains = generics.compute_diag_inverse

--- a/cubical/machines/complex_W_2x2_machine.py
+++ b/cubical/machines/complex_W_2x2_machine.py
@@ -5,12 +5,12 @@
 from __future__ import print_function
 from cubical.machines.interval_gain_machine import PerIntervalGains
 import numpy as np
-from scipy import special
+from scipy import special, stats
 from cubical.flagging import FL
 import cubical.kernels
 import time
 
-from cubical.tools import logger
+from cubical.tools import logger, ModColor
 log = logger.getLogger("robust_2x2")  #TODO check this "complex_2x2"
 
 class ComplexW2x2Gains(PerIntervalGains):
@@ -44,7 +44,10 @@ class ComplexW2x2Gains(PerIntervalGains):
 
         PerIntervalGains.__init__(self, label, data_arr, ndir, nmod, chunk_ts, chunk_fs, chunk_label, options)
 
-        self.kernel_robust = cubical.kernels.import_kernel("full_W_complex")
+        if self.is_diagonal:
+            self.kernel_robust = cubical.kernels.import_kernel("diag_robust")
+        else:
+            self.kernel_robust = cubical.kernels.import_kernel("full_W_complex")
 
         self.residuals = np.empty_like(data_arr)
 
@@ -52,17 +55,78 @@ class ComplexW2x2Gains(PerIntervalGains):
         
         self.label = label
 
-        self.cov_type = options.get("robust-cov", "compute") #adding an option to compute residuals covariance or just assume 1 as in Robust-t paper
+        self.cov_type = options.get("robust-cov", "compute") # adding an option to compute residuals covariance or just assume 1 as in Robust-t paper
 
-        self.npol = options.get("robust-npol", 2.) #testing if the number of polarizations really have huge effects
+        self.npol = options.get("robust-npol", 2.) # testing if the number of polarizations really have huge effects
 
-        self.v_int = options.get("robust-int", 1)
+        self.v_int = options.get("robust-int", 5)
 
-        self.cov_scale = options.get("robust-scale", True) # scale the covariance by n_corr*2
+        self.cov_scale = options.get("robust-scale", 0) # scale down the covariance by this factor
+
+        self.cov_thresh = options.get("robust-cov-thresh",  1)
+
+        self.sigma_thresh = options.get("robust-sigma-thresh", 3)
+
+        self.robust_flag_weights = options.get("robust-flag-weights", True)
+
+        self.fixed_v = False
+
+        self.not_all_flagged = True
+
+        self._flag = True
+
+        self.any_new = 0
+
+        self.is_robust = True # to identify this machine as the robust solver
+
+        self._estimate_pzd = options["estimate-pzd"]
+
+        # this will be set to PZD and exp(-i*PZD) once the PZD estimate is done
+        self._pzd = 0
+        self._exp_pzd = 1
+
 
     @classmethod
     def determine_diagonality(cls, options):
-        return False
+        """Returns true if the machine class, given the options, represents a diagonal gain"""
+        updates = set(options['update-type'].split("-"))
+        return options['type'] == 'robust-diag' or \
+               ('full' not in updates and 'leakage' not in updates)
+
+    @staticmethod
+    def exportable_solutions():
+        """ Returns a dictionary of exportable solutions for this machine type. """
+        sols = PerIntervalGains.exportable_solutions()
+        sols["pzd"] = (0.0, ("time", "freq"))
+        return sols
+
+    def importable_solutions(self, grid0):
+        """ Returns a dictionary of importable solutions for this machine type. """
+        sols = super(ComplexW2x2Gains, self).importable_solutions(grid0)
+        if "pzd" in self.update_type:
+            sols["pzd"] = dict(**self.interval_grid)
+        return sols
+
+    def export_solutions(self):
+        """ Saves the solutions to a dict of {label: solutions,grids} items. """
+        sols = super(ComplexW2x2Gains, self).export_solutions()
+        if "pzd" in self.update_type and self._pzd is not None:
+            sols["pzd"] = (masked_array(self._pzd), self.interval_grid)
+        return sols
+
+    def import_solutions(self, soldict):
+        """
+        Loads solutions from a dict.
+
+        Args:
+            soldict (dict):
+                Contains gains solutions which must be loaded.
+        """
+        if "pzd" in self.update_type and "pzd" in soldict:
+            self._pzd = soldict["pzd"]
+            self._exp_pzd = np.exp(-1j * self._pzd)
+
+        super(ComplexW2x2Gains, self).import_solutions(soldict)
 
     def compute_js(self, obser_arr, model_arr):
         """
@@ -85,27 +149,40 @@ class ComplexW2x2Gains(PerIntervalGains):
             
             flag_count:     Number of flagged (ill-conditioned) elements
         """
-        w = self.weights
+        # w = self.weights
         
         n_dir, n_tim, n_fre, n_ant, n_cor, n_cor = self.gains.shape
 
+        # compute residuals and weights
+        if self.iters == 1:
+            self.residuals = self.compute_residual(obser_arr, model_arr, self.residuals)
+
+            if self.not_all_flagged:
+                self.update_weights()
+
+
         jh = self.get_new_jh(model_arr)
+
+        if self.offdiag_only:
+            jh[...,(0,1),(0,1)] = 0
+            self.residuals[...,(0,1),(0,1)] = 0
+            
+        if self.diag_only:
+            jh[...,(0,1),(1,0)] = 0
+            self.residuals[...,(0,1),(1,0)] = 0
 
         self.kernel_robust.compute_jh(model_arr, self.gains, jh, self.t_int, self.f_int)
 
         jhwr = self.get_new_jhr()
 
-        if self.iters == 1:
-            self.residuals = self.compute_residual(obser_arr, model_arr, self.residuals)
-
-        self.kernel_robust.compute_jhwr(jh, self.residuals, w, jhwr, self.t_int, self.f_int) #TODO 
+        self.kernel_robust.compute_jhwr(jh, self.residuals, self.weights, jhwr, self.t_int, self.f_int) #TODO 
 
         jhwj, jhwjinv = self.get_new_jhj()
 
-        self.kernel_robust.compute_jhwj(jh, w, jhwj, self.t_int, self.f_int)
+        self.kernel_robust.compute_jhwj(jh, self.weights, jhwj, self.t_int, self.f_int)
 
         flag_count = self.kernel_robust.compute_jhjinv(jhwj, jhwjinv, self.gflags, self.eps, FL.ILLCOND)
-
+        
         return jhwr, jhwjinv, flag_count
 
     
@@ -120,20 +197,23 @@ class ComplexW2x2Gains(PerIntervalGains):
         
         #----normalising to reduce the effects of the weights on jhj---#
         #----not sure if this is the best way to do this---------------#
-        
-        norm = ((1/2.)*np.average(self.weights[:,self.new_flags==0,:].real))**2
-        diag = norm*jhjinv[..., (0, 1), (0, 1)].real
+
+        self.Nvis = np.sum(self.new_flags==False)
+        try:
+            norm = np.min(self.weights[np.where(self.weights>0)]).real #np.real((1/2.)*np.sum(self.weights)) #/self.Nvis
+        except:
+            norm = 0
+        diag = norm*jhjinv[..., (0, 1), (0, 1)].real #/np.max(self.weights)
         self.posterior_gain_error[...,(0,1),(0,1)] = np.sqrt(diag)
         self.posterior_gain_error[...,(1,0),(0,1)] = np.sqrt(diag.sum(axis=-1)/2)[...,np.newaxis]
 
         update = self.init_update(jhr)
         self.kernel_robust.compute_update(jhr, jhjinv, update)
 
+
         # if self.dd_term and self.n_dir > 1: computing residuals for both DD and DID calibration
         update += self.gains
         self.restrict_solution(update)
-        # raise flag so updates of G^H and G^-1 are computed
-        self._gh_update = self._ghinv_update = True
 
         if self.iters % 2 == 0 or self.n_dir > 1:
             self.gains += update
@@ -159,16 +239,16 @@ class ComplexW2x2Gains(PerIntervalGains):
                 Shape (n_mod, n_tim, n_fre, n_ant, n_ant, n_cor, n_cor) array containing observed 
                 visibilities. 
         """
-        
+
         jhwr, jhwjinv, flag_count = self.compute_js(obser_arr, model_arr)
 
         self.implement_update(jhwr, jhwjinv)
 
         # Computing the weights
-        
-        self.residuals = self.compute_residual(obser_arr, model_arr, self.residuals)
 
-        self.update_weights()
+        if self.not_all_flagged:
+            self.residuals = self.compute_residual(obser_arr, model_arr, self.residuals)
+            self.update_weights()
 
         return flag_count
 
@@ -195,49 +275,71 @@ class ComplexW2x2Gains(PerIntervalGains):
           
         else:
 
-            unflagged = self.new_flags==False 
-
-            Nvis = np.sum(unflagged)/2. #only half of the visibilties are used for covariance computation
+            Nvis = self.Nvis/2. #only half of the visibilties are used for covariance computation
 
             ompstd = np.zeros((4,4), dtype=self.dtype)
 
             self.kernel_robust.compute_cov(self.residuals, ompstd, self.weights)
 
-            #---scaling the variance in this case improves the robust solver performance----------#
-            #---if the covariance and variance are close the residuals are dominated by sources---#
-            if self.cov_scale:
-                if 0.6 <= np.abs(ompstd[0,0])/np.abs(ompstd[0,3]) <= 1.5:
-                    norm = 2*self.npol*Nvis
+            # removing the offdiagonal correlations
+            std = np.diagonal(ompstd/Nvis) + self.eps**2 # To avoid division by zero
+
+            if np.any(std>self.cov_thresh):
+                self.fixed_v = True
+                
+                if self.flaground:
+                    print(ModColor.Str("rb-2x2 {} : flag round {}: Warning Covariance too high probably because of RFI will fixed v to 2 and cov to 1".format(self.label, self._count+1), "red"), file=log(2))
                 else:
-                    norm = Nvis
+                    print(ModColor.Str("rb-2x2 {} : {} iters: Warning Covariance too high probably because of RFI will fixed v to 2 and cov to 1".format(self.label, self.iters), "red"), file=log(2))
+
             else:
-                norm = Nvis
+                #---scaling the variance in this case improves the robust solver performance----------#
+                self.fixed_v = False
+                if self.cov_scale and not self.flaground:
+                    std /= self.cov_scale 
 
             if self.iters % 5 == 0 or self.iters == 1:
-                print("{} : {} iters: covariance is  {}".format(self.label, self.iters, ompstd/Nvis), file=log(2))
+                if self.flaground:
+                    print("rb-2x2 {} : flag round {}: covariance diagonal : [{}]".format(self.label, self._count+1, ", ".join('{:.2g}'.format(x) for x in std)), file=log(2))
+                    # print("rb-2x2 {} : flag round {}: covariance diagonal : [{}]".format(self.label, self._count+1, ", ".join('{:.2g}'.format(x) for x in std2)), file=log(2))
+                else:
+                    print("rb-2x2 {} : {} iters: covariance diagonal : [{}]".format(self.label, self.iters, ", ".join('{:.2g}'.format(x) for x in std)), file=log(2))
+                    # print("rb-2x2 {} : {} iters: covariance diagonal : [{}]".format(self.label, self.iters, ", ".join('{:.2g}'.format(x) for x in std2)), file=log(2))
 
-            # removing the offdiagonal correlations
 
-            std = np.diagonal(ompstd/norm) + self.eps**2 # To avoid division by zero
+            # can we disable the flagging the solver to avoid flagging unmodelled sources
+            # UMS: my thought here is that if data is unmodelled sources rather than RFI xx and yy covariance should be very close
+            # so the solver should disable the flagging in this case
+            xx_close_to_yy = 0.8 <= np.abs(std[0])/np.abs(std[0]) <= 1.2
+            cov_low = np.average([std[0], std[3]]).real < 2e-2
+
+            if xx_close_to_yy and cov_low and self.flaground and self._count==0:
+                self.robust_flag_disable = True
+                print(ModColor.Str("rb-2x2 {} : flag round {}: Warning: the covariance is low and the xx and yy variances are very close. Flagging will be disable".format(self.label, self._count+1), "red"), file=log(2))
+
 
             covinv = np.eye(4, dtype=self.dtype)
 
-            if self.cov_type == "hybrid":
-                if np.max(np.abs(std)) < 1:
-                    covinv[np.diag_indices(4)]= 1/std
-                    
-            elif self.cov_type == "compute":
-                covinv[np.diag_indices(4)]= 1/std
-               
+            if self.fixed_v:
+                covinv *= 1/self.cov_thresh
             else:
-                raise RuntimeError("unknown robust-cov setting")
+                if self.cov_type == "hybrid":
+                    if np.max(np.abs(std)) < 1:
+                        covinv[np.diag_indices(4)]= 1/std
+                
+                elif self.cov_type == "compute":
+                    covinv[np.diag_indices(4)]= 1/std
+                else:
+                    raise RuntimeError("unknown robust-cov setting")
         
         if self.npol == 2:
             covinv[(1,2), (1,2)] = 0
-            
 
-        return covinv
-    
+
+        self.covinv = covinv
+
+        # print("rb-2x2 {} : {} iters: hybrid check covariance diagonal : [{}]".format(self.label, self.iters, ", ".join('{:.2g}'.format(x) for x in np.diagonal(covinv))), file=log(2))
+
 
     def update_weights(self):
         
@@ -260,10 +362,11 @@ class ComplexW2x2Gains(PerIntervalGains):
         def  _brute_solve_v(wn):
             """Finds a root for the function f constraint between low (2) and high (50)
             Args:
-                wn : the weights flaten in to a 1D array
+                wn : the weights flatenncc-a-b in to a 1D array
             Returns:
                 root (float) : The root of f or minimum point    
             """
+            # import pdb; pdb.set_trace()
 
             m = len(wn)
 
@@ -276,47 +379,196 @@ class ComplexW2x2Gains(PerIntervalGains):
             fvals = vfunc(vvals)
             root = vvals[np.argmin(np.abs(fvals))]
 
-            if self.iters % 5 == 0 or self.iters == 1:
-                print("{} : {} iters: v-parameter is  {}".format(self.label, self.iters, root), file=log(2))
+            if self.flaground:
+                print("rb-2x2 {} : flag round {}: v-parameter is  {:.3}".format(self.label, self.iters, root), file=log(2))
+                print("rb-2x2 {} : flag round {} : weights stats are min {:.4}, max: {:.4}, mean: {:.4}, std: {:.4}, median: {:.4}, mad: {:.4}".format(self.label, self._count+1, np.min(wn), 
+                                                    np.max(wn), np.mean(wn), np.std(wn), np.median(wn), stats.median_absolute_deviation(wn)), file=log(2)) 
+            else:
+                
+                if self.iters % 5 == 0 or self.iters == 1:
+                    print("rb-2x2 {} : {} iters: v-parameter is  {:.3}".format(self.label, self.iters, root), file=log(2))
+                    #nless, nmore = len(wn[wn<1])/len(wn), len(wn[wn>1])/len(wn)
+                    print("rb-2x2 {} : {} iters: weights stats are min {:.4}, max: {:.4}, mean: {:.4}, std: {:.4}, median: {:.4}, mad: {:.4}".format(self.label, self.iters, np.min(wn), 
+                                                    np.max(wn), np.mean(wn), np.std(wn), np.median(wn), stats.median_absolute_deviation(wn)), file=log(2)) #, np.sum(wn), m, nless, nmore, 
             
-            return root
+            if self.fixed_v:
+                return 2
+            else:    
+                return root
 
-        covinv = self.compute_covinv()
+        if self.iters % self.v_int == 0 or self.iters == 1:
+            self.compute_covinv()
 
-        w , v  = self.weights, self.v
+        if self.fixed_v:
+            self.v = 2
 
-        # import pdb; pdb.set_trace()
+        self.kernel_robust.compute_weights(self.residuals, self.covinv, self.weights, self.v, self.npol)
 
-        self.kernel_robust.compute_weights(self.residuals, covinv, w, v, self.npol)
-
-        # re-set weights for visibillities flagged from start to 0
-        w[:,self.new_flags,:] = 0
-
-        #---------normalising the weights to mean 1 using only half the weights--------------------------#
+        # re-set weights for visibillities flagged from start to 0 and normalise the weights by their sum 
+        self.weights[:,self.new_flags!=0,:] = 0
+        
         aa, ab = np.tril_indices(self.n_ant, -1)
-        w_real = np.real(w[:,:,:,aa,ab,0].flatten())
-        w_nzero = w_real[np.where(w_real!=0)[0]]  #removing zero weights for the v computation
+        w_real = np.real(self.weights[:,:,:,aa,ab,0].flatten())
+        w_nzero = w_real[np.where(w_real!=0)[0]]
+        norm = np.average(w_nzero)
 
-        # norm = np.average(w_nzero) 
-  
-        self.weights = w #/norm
+        self.weights/= norm
+        w_nzero/=norm
+        
+        # wstd = np.std(w_nzero) #stats.median_absolute_deviation(w_nzero)
+        # wmean = 1 #np.median(w_nzero)
         
         #-----------computing the v parameter---------------------#
         # This computation is only done after a certain number of iterations. Default is 5
         if self.iters % self.v_int == 0 or self.iters == 1:
-            wn = w_nzero #/norm 
-            self.v = _brute_solve_v(wn)
+            self.v = _brute_solve_v(w_nzero) # remove zero weights
+
+        self.not_all_flagged = self.flag_weights()
         
-        return 
+        return
+
+    def flag_weights(self):
+        """Trying flagging visiblities with very very low weights and see if this improves the solution
+        like mad max flagger
+
+        wstd: the weights standard deviation
+        """
+
+        if self.flaground and not self.robust_flag_disable:
+
+            if self._final_flaground:
+                _pre_or_post = "after-solving"   
+            else:
+                _pre_or_post = "before solving"
+
+            _nvis = self.new_flags.size
+            nflag0 = np.sum(self.new_flags!=0)
+            wfrac0 = nflag0/_nvis
+
+            # This correction factor is two ensure that we only flag when v is low.
+            # The 1.26 factor is just makes it work somehow 
+            _v_corr = 1.26/self.v #2*self.npol/self.v if self.v < 5 else self.npol/self.v
+
+            wlow =  _v_corr*(self.v + self.npol)/(self.v + self.sigma_thresh)
+
+            # print("rb-2x2 {} : {} iters: wlow is  {:.3} while 1/v is {:.3}".format(self.label, self.iters, wlow, 1/self.v), file=log(2))
+
+            self.weight_flags = np.where((self.weights< wlow) & (self.weights!=0)) # wlow
+
+            # import pdb; pdb.set_trace()
+
+            if len(self.weight_flags[0])>0:
+
+                self.weights[self.weight_flags] = 0
+                self.new_flags[self.weight_flags[1:-1]] |= FL.MAD
+                self.residuals[self.weight_flags[:-1]] = 0
+
+                nflag = np.sum(self.new_flags!=0)
+
+                any_new = nflag-nflag0
+
+                if any_new:
+                    wfrac = any_new/_nvis
+                    
+                    print(ModColor.Str("rb-2x2 {} : {} flag round {} : number of weight flags {} ({:.4%}), prior flags {} ({:.4%})".format(self.label, _pre_or_post, self._count+1, any_new, wfrac, nflag0, wfrac0), "blue"), file=log(2))
+                
+                self.any_new = True
+
+                self._count += 1 
+                
+                return False if nflag ==_nvis else True
+
+            else:
+                if self._count==0:
+                    self.any_new = False 
+                return True
+        
+        else:
+            self.any_new = False
+            self.weight_flags = None 
+            
+            return True
+
+
+    def update_weight_flags(self, flags_arr):
+
+        self.new_flags = flags_arr
+        self.weights[:,self.new_flags!=0,:] = 0
+        
+        self.Nvis = np.sum(self.new_flags==False)
+
+        self.not_all_flagged = False if self.Nvis==0 else True
+
+    def robust_flag(self, flags_arr, model_arr, obser_arr, final=False):
+        """run an iteration and use the weights to flag high level RFIs"""
+
+        self.flaground = True
+
+        if final is False:
+            self.v = 5  # Don't start with a low degree of freedom to prevent overflagging
+            self.iters = 1
+
+        self._final_flaground = True if final else False
+
+        if final and self.not_all_flagged:
+            self.flag_weights()
+        else:
+            self.compute_update(model_arr, obser_arr)
+            np.copyto(self.gains, self.old_gains)
+
+        if self.any_new:
+            flags_arr[self.weight_flags[1:-1]] |= FL.MAD
+            self.update_equation_counts(flags_arr != 0)
+
+            new_flags = flags_arr & ~(FL.MISSING | FL.PRIOR) != 0
+                
+            model_arr[:, :, new_flags!=0, :, :] = 0
+            obser_arr[   :, new_flags!=0, :, :] = 0
+
+        if final is False:
+            self.weights[:, self.new_flags==0, :] = 1
+            self.iters = 0
+            self.v = 2
+            self._gh_update = self._ghinv_update = True
+
+        self.flaground = False
 
     def restrict_solution(self, gains):
         
-        PerIntervalGains.restrict_solution(self, gains)
+        
+        if "pzd" in self.update_type:
+            # re-estimate pzd
+            mask = self.gflags!=0
+            with np.errstate(divide='ignore', invalid='ignore'):
+                pzd = masked_array(gains[:, :, :, :, 0, 0] / gains[:, :, :, :, 1, 1], mask)
+            pzd = np.angle(pzd.sum(axis=(0,3)))
+            with np.printoptions(precision=4, suppress=True, linewidth=1000):
+                print("{0}: PZD estimate changes by {1} deg".format(self.chunk_label, (pzd-self._pzd)* 180 / np.pi), file=log(2))
+            # import ipdb; ipdb.set_trace()
+            self._pzd = pzd
+            self._exp_pzd = np.exp(-1j * pzd)
+
+            gains[:, :, :, :, 0, 0] = 1
+            gains[:, :, :, :, 1, 1] = self._exp_pzd[np.newaxis, :, :, np.newaxis]
+            
+        if "leakage" in self.update_type:
+            if "pzd" not in self.update_type:
+                gains[:, :, :, :, 0, 0] = 1
+                gains[:, :, :, :, 1, 1] = 1
+                
+            if "rel" in self.update_type and self.ref_ant is not None:
+                offset =  gains[:, :, :, self.ref_ant, 0, 1].copy()
+                gains[..., 0, 1] -= offset[..., np.newaxis]
+                gains[..., 1, 0] += np.conj(offset)[..., np.newaxis]
+                with np.printoptions(precision=4, suppress=True, linewidth=1000):
+                    print("{0}: subtracting relative leakage offset {1}".format(self.chunk_label, offset), file=log(2))
+
 
         if self.ref_ant is not None:
-            phase = np.angle(gains[...,self.ref_ant,0,0])
+            phase = np.angle(self.gains[...,self.ref_ant,0,0])
             gains[:,:,:,:,(0,1),(0,1)] *= np.exp(-1j*phase)[:,:,:,np.newaxis,np.newaxis]
 
+        super(ComplexW2x2Gains, self).restrict_solution(gains)
 
 
     def precompute_attributes(self, data_arr, model_arr, flags_arr, noise):
@@ -330,12 +582,61 @@ class ComplexW2x2Gains(PerIntervalGains):
             flags_arr (np.ndarray):
                 Shape (n_tim, n_fre, n_ant, n_ant) array containing  flags
         """
-        PerIntervalGains.precompute_attributes(self, data_arr, model_arr, flags_arr, noise)
+        
+        super(ComplexW2x2Gains, self).precompute_attributes(data_arr, model_arr, flags_arr, noise)
+
+        if self._estimate_pzd and self._pzd is 0:
+            marr = model_arr[..., (0, 1), (1, 0)][:, 0].sum(0)
+            darr = data_arr[..., (0, 1), (1, 0)][0]
+            mask = (flags_arr[..., np.newaxis] != 0) | (marr == 0)
+            with np.errstate(divide='ignore', invalid='ignore'):
+                dm = darr * (np.conj(marr) / abs(marr))
+            dabs = np.abs(darr)
+            dm[mask] = 0
+            dabs[mask] = 0
+            # collapse time/freq axis into intervals and sum antenna axes
+            dm_sum = self.interval_sum(dm).sum(axis=(2, 3))
+            dabs_sum = self.interval_sum(dabs).sum(axis=(2, 3))
+            # sum off-diagonal terms
+            dm_sum = dm_sum[..., 0] + np.conj(dm_sum[..., 1])
+            dabs_sum = dabs_sum[..., 0] + np.conj(dabs_sum[..., 1])
+            pzd = np.angle(dm_sum / dabs_sum)
+            pzd[dabs_sum == 0] = 0
+            with np.printoptions(precision=4, suppress=True, linewidth=1000):
+                print("{0}: PZD estimate {1} deg".format(self.chunk_label, pzd * 180 / np.pi), file=log(2))
+            self._pzd = pzd
+            self._exp_pzd = np.exp(-1j * pzd)
+
+            self.gains[:, :, :, :, 0, 0] = 1
+            self.gains[:, :, :, :, 1, 1] = self._exp_pzd[np.newaxis, :, :, np.newaxis]
 
         self.weights_shape = [self.n_mod, self.n_tim, self.n_fre, self.n_ant, self.n_ant, 1]
         
         self.weights = np.ones(self.weights_shape, dtype=self.dtype)
-        self.weights[:,flags_arr!=0] = 0
-        self.new_flags = flags_arr!=0
 
-        self.v = 2.   # t-distribution number of degrees of freedom
+        self.v = 2 # t-distribution number of degrees of freedom
+
+        self.covinv = np.eye(4, dtype=self.dtype)
+
+        self.weight_flags = None
+
+        self.update_weight_flags(flags_arr)
+
+        self.flaground = False
+
+        self._final_flaground = False
+
+        self.robust_flag_disable = False
+
+        self._count = 0
+
+    @property
+    def dof_per_antenna(self):
+        if "leakage" in self.update_type and "pzd" in self.update_type:
+            return 4 + 1./self.n_ant
+        elif "leakage" in self.update_type:
+            return 4
+        elif "pzd" in self.update_type:
+            return 1./self.n_ant
+        else:
+            return super(ComplexW2x2Gains, self).dof_per_antenna

--- a/cubical/machines/interval_gain_machine.py
+++ b/cubical/machines/interval_gain_machine.py
@@ -476,8 +476,6 @@ class PerIntervalGains(MasterMachine):
             if self.dd_term:
                 self.prior_gain_error[self.fix_directions, ...] = 0
 
-            # import ipdb; ipdb.set_trace()
-
             # if we did everything right above (ignoring flagged data etc.), PGE can't be inf/nan,
             # so this is just a sanity check
             pge_flag_invalid = np.isnan(self.prior_gain_error) | np.isinf(self.prior_gain_error)

--- a/cubical/machines/machine_types.py
+++ b/cubical/machines/machine_types.py
@@ -13,6 +13,7 @@ GAIN_MACHINE_TYPES = {
     'complex-pol': pol_gain_machine.PolarizationGains,
     'phase-diag': phase_diag_machine.PhaseDiagGains,
     'robust-2x2': complex_W_2x2_machine.ComplexW2x2Gains,
+    'robust-diag': complex_W_2x2_machine.ComplexW2x2Gains, 
     'f-slope': slope_machine.PhaseSlopeGains,
     't-slope': slope_machine.PhaseSlopeGains,
     'tf-plane': slope_machine.PhaseSlopeGains

--- a/cubical/main.py
+++ b/cubical/main.py
@@ -36,7 +36,7 @@ from cubical.tools import logger
 # (Thus before anything else that uses the logger is imported!)
 logger.init("cc")
 
-# Some modules cause issues with logging - grab their loggers and
+# Some modules cause issues with logging - grab their loggers and 
 # manually set the log levels to something less annoying.
 
 import logging
@@ -427,7 +427,7 @@ def main(debugging=False):
             jones_class = machine_types.get_machine_class(jones_opts['type'])
             if jones_class is None:
                 raise UserInputError("unknown Jones type '{}'".format(jones_opts['type']))
-        elif jones_opts[0]['type'] == "robust-2x2":
+        elif jones_opts[0]['type'].startswith("robust"):
             jones_class = jones_chain_robust_machine.JonesChain
         else:
             jones_class = jones_chain_machine.JonesChain
@@ -668,4 +668,3 @@ def main(debugging=False):
                 exc, value, tb = sys.exc_info()
                 pdb.post_mortem(tb)
         sys.exit(2 if type(exc) is UserInputError else 1)
-

--- a/cubical/solver.py
+++ b/cubical/solver.py
@@ -85,6 +85,9 @@ def _solve_gains(gm, stats, madmax, obser_arr, model_arr, flags_arr, sol_opts, l
 
     diverging = ""
 
+    # for all the solvers that do not output any weights and for the robust solver when they are no valid solutions
+    gm.output_weights = None 
+
     # Estimates the overall noise level and the inverse variance per channel and per antenna as
     # noise varies across the band. This is used to normalize chi^2.
 
@@ -154,6 +157,13 @@ def _solve_gains(gm, stats, madmax, obser_arr, model_arr, flags_arr, sol_opts, l
             gm.update_equation_counts(flags_arr != 0)
             stats.chunk.num_mad_flagged = ((flags_arr & FL.MAD) != 0).sum()
 
+
+    # apply robust flag if robust machine (this uses the madmax flag)
+    if hasattr(gm, 'is_robust'):
+        if gm.robust_flag_weights:
+            gm.robust_flag(flags_arr, model_arr, obser_arr)
+            stats.chunk.num_mad_flagged = ((flags_arr & FL.MAD) != 0).sum()
+
     # In the event that there are no solutions with valid data, this will log some of the
     # flag information and break out of the function.
     stats.chunk.num_solutions = gm.num_solutions
@@ -202,6 +212,7 @@ def _solve_gains(gm, stats, madmax, obser_arr, model_arr, flags_arr, sol_opts, l
     # Main loop of the NNLS method. Terminates after quorum is reached in either converged or
     # stalled solutions or when the maximum number of iterations is exceeded.
 
+    
     major_step = 0  # keeps track of "major" solution steps, for purposes of collecting stats
 
 
@@ -226,7 +237,7 @@ def _solve_gains(gm, stats, madmax, obser_arr, model_arr, flags_arr, sol_opts, l
         gm.compute_update(model_arr, obser_arr)
 
         # flag solutions. This returns True if any flags have been propagated out to the data.
-        if gm.flag_solutions(flags_arr, 0):
+        if gm.flag_solutions(flags_arr, False):
 
             update_stats(flags_arr, ('chi2',))
 
@@ -237,14 +248,12 @@ def _solve_gains(gm, stats, madmax, obser_arr, model_arr, flags_arr, sol_opts, l
             # propagated out to the data, then that slot is gone gone gone and should be zeroe'd everywhere.
 
             new_flags = flags_arr&~(FL.MISSING|FL.PRIOR) !=0
+           
             model_arr[:, :, new_flags, :, :] = 0
             obser_arr[   :, new_flags, :, :] = 0
 
             stats.chunk.num_sol_flagged = gm.num_gain_flags()[0]
 
-            # Adding the below lines for the robust solver so that flags should be apply to the weights
-            if hasattr(gm, 'new_flags'):
-                gm.new_flags = new_flags
 
         # Compute values used in convergence tests. This check implicitly marks flagged gains as
         # converged.
@@ -273,6 +282,7 @@ def _solve_gains(gm, stats, madmax, obser_arr, model_arr, flags_arr, sol_opts, l
             thr1, thr2 = madmax.get_mad_thresholds()
             if thr1 or thr2:
                 num_mad_flagged_prior = int(stats.chunk.num_mad_flagged)
+
                 if madmax.beyond_thunderdome(resid_arr, obser_arr, model_arr, flags_arr, thr1, thr2,
                                              "{} iter {} ({})".format(label, num_iter, gm.jones_label)):
                     gm.update_equation_counts(flags_arr != 0)
@@ -309,10 +319,6 @@ def _solve_gains(gm, stats, madmax, obser_arr, model_arr, flags_arr, sol_opts, l
                     log.warn("{}: {:.2%} slots diverging, {} new data flags".format(label,
                                     diverged_tf_slots.sum()/float(diverged_tf_slots.size), num_nf))
 
-                    # Adding the below lines for the robust solver so that flags should be apply to the weights
-                    if hasattr(gm, 'new_flags'):
-                        gm.new_flags |= new_flags
-
             stats.chunk.frac_stalled = stats.chunk.num_stalled / float(chi.size)
             stats.chunk.frac_diverged = stats.chunk.num_diverged / float(chi.size)
 
@@ -340,6 +346,9 @@ def _solve_gains(gm, stats, madmax, obser_arr, model_arr, flags_arr, sol_opts, l
                                     stats.chunk.chi2u, delta_chi_mean, delta_chi_max,
                                     float(1-stats.chunk.frac_stalled), diverging))
 
+        # Adding the below lines for the robust solver so that flags should be apply to the weights
+        if hasattr(gm, 'is_robust'):
+            gm.update_weight_flags(flags_arr)
 
 
     # num_valid_solutions will go to 0 if all solution intervals were flagged. If this is not the
@@ -347,7 +356,7 @@ def _solve_gains(gm, stats, madmax, obser_arr, model_arr, flags_arr, sol_opts, l
 
     if gm.has_valid_solutions:
         # Final round of flagging
-        flagged = gm.flag_solutions(flags_arr, 1)
+        flagged = gm.flag_solutions(flags_arr, True)
         stats.chunk.num_sol_flagged = gm.num_gain_flags()[0]
     else:
         flagged = None
@@ -400,11 +409,20 @@ def _solve_gains(gm, stats, madmax, obser_arr, model_arr, flags_arr, sol_opts, l
         resid_arr = obser_arr
 
     robust_weights = None
-    if hasattr(gm, 'save_weights'):
+    if hasattr(gm, 'is_robust'):
+        
+        # do a last round of robust flag robust flag and save the weights
+         
+        if gm.robust_flag_weights and not gm.robust_flag_disable:
+            gm.robust_flag(flags_arr, model_arr, obser_arr, final=True)
+            stats.chunk.num_mad_flagged = ((flags_arr & FL.MAD) != 0).sum()
+        
         if gm.save_weights:
             newshape = gm.weights.shape[1:-1] + (2,2)
             robust_weights = np.repeat(gm.weights.real, 4, axis=-1)
             robust_weights = np.reshape(robust_weights, newshape)
+            gm.output_weights = robust_weights
+        
 
     # After the solver loop check for warnings from the solvers
     for d in gm.collect_warnings():
@@ -635,7 +653,6 @@ class SolverMachine(object):
         """
         Finalizes the output visibilities, running a pass of the flagger on them, if configured
         """
-#        import ipdb; ipdb.set_trace()
         
         # clear out MAD flags if madmax was in trial mode
         if self.stats.chunk.num_mad_flagged and self.madmax.trial_mode:
@@ -709,6 +726,8 @@ class SolveOnly(SolverMachine):
         _solve_gains(self.gm, self.stats, self.madmax,
                      self.vdm.weighted_obser, self.vdm.weighted_model, self.vdm.flags_arr,
                      self.sol_opts, label=self.label)
+
+        self.output_weights = self.gm.output_weights
 
         if ifrgain_machine.is_computing():
             ifrgain_machine.update(self.vdm.weighted_obser, self.vdm.corrupt_weighted_model, self.vdm.flags_arr,


### PR DESCRIPTION
* fixes #274. Also includes timings to shed light on #277 discussion

* fixes #279

* extended effect of --debug-escalate-warnings option to other types of warnings

* fixed some options for escalating warnings to exception level

* remove weights scaling and changed log file to robust_2x2

* fixed previous commit following commit errors to incorporate the normalisation in the variance

* fixed denominator computation in weight_upd_product

* fixed covariance normalisation in numba kernel

* add covariance scaling option

* comparing numba and cython robust

* comparing numba and cython

* fixing covariance normalisation in numba

* fixed covariance scale option in numba kernel

* Updated complex_w_2x2_machine

Fixed printing in python 3

* fixed python 3 and 2 printing conflict

* fixed robust chain machine to work with numba kernels

* Normalising the posterior variance

I added a normalisation, to remove the effects of the weights on the estimated gain posterior variance.

* more work on #274

* started fixing the logic for determining invalid gain intervals etc.

* multiple fixes to gain flagging

* added --data-normalize option

* more additions for --data-normalize

* fixes to ref antenna in phase and slope machines

* * fixed --sol-term-iterms default
* made QUV optional in LSMs
* fixed derotation of output visibilities which wasn't working at all
* fixed division by zero messages

* started work on #326

* fixes #326, I think. Maybe fixes #324

* continuing #326

* more fixes to PZD treatment

* more fixes to PZD treatment

* more fixes to PZD

* more fixes to PZD treatment

* more messing with PZD -- time to break this out into a separate machine

* extracted polcal into a separate machine. Added scalar updates.

* playing with better PZD estimation

* added PZD re-estimation

* changed export CASA gaintables to off in constructor, since this is set from GD explicitly

* fixes for intervals in gain flagging

* reinstated estimate-pzd option

* allowing a full update type for complex-pol

* merging pol_gain_machine back in as an update type

* more fixes to leakage gains

* added derotation of PA in output even when model is not totated

* fixed param lookup for discrete axes

* fixed param lookup for discrete axes, again

* temporarily disabled diag-diag kernels, as something seems off with them

* added plotting script for leakages

* added rel-leakage update type

* fixed print statements for elative leakages

* fixing printing and division errors

* added/refactored bandpass and leakage plotting scripts

* removed separate plot-gains script, will be symlink

* added back plot-gains as symlink

* more work on plotting scripts

* three types of plotting scripts (G/B/D) now work

* more fixes to plots

* Minor fixes for strange divergence bug. Note that this is only fixed in the delay solver.

* more fixes to plotting scripts

* made unified plotting script that auto-detects G/B/D type

* more small fixes to plots

* Fixed reference antenna code to reference with respect to first correlation.

* overhauled chi-sq computation to (hopefully) take diag-only and offdiag-only into account

* fixed updates of diag-only modes

* Initial (mostly working) example of delay by FFT initial guess.

* Added comments to make current code a little clearer. Need to add functionality for frequency intervals.

* Support for several delays across frequency.

* Working delay estimate. Requires further testing but seems to work.

* Minor fixes for strange divergence bug. Note that this is only fixed … (#330)

* Minor fixes for strange divergence bug. Note that this is only fixed in the delay solver.

* Fixed reference antenna code to reference with respect to first correlation.

* Initial (mostly working) example of delay by FFT initial guess.

* Added comments to make current code a little clearer. Need to add functionality for frequency intervals.

* Support for several delays across frequency.

* Working delay estimate. Requires further testing but seems to work.

* merged in delay estimators

* fixed plot-gain-solutions to also print delays etc. Added option for skipping slope estimates. Print initial slope estimates.

* fixes to data normalization, fixes #334 (madmax threshold treatment), and various debugging of f-slope estimators

* multiple fixes to gain plotters. Added flagging of diverging slots. Made MadMax also flag SKIPSOL slots in the final rounds

* Minor fixes and changes to the f-slope machine.

* Fix for excessive padding bug.

* Added options for pinning delay solutions when solving for slopes.

* fixes bug with saving of DD vs non DD terms in chain

* added --out-correct-dir option

* fixed bug where DI terms in a chain would not try to load all directions and fail

* fixed subtract-dir treatment for DI terms

* compute covariance only when the v parameter is recomputed

* fixed saving weights with robust chain machine

* change robust log file to solver only for simulations

* fixed chain robut solver to work with the branch issue-326-chisq-jsq

* checking flags propagation in robust weights

* Fixed weights saving and added flagging with weigths of the robust machine

* Add a robust-diag kernel
Add options for flagging with the robust machine
Fixed chi-square computation for the robust machine

* conflict in interval gain machine

* updated to robust_2x2 log file

* remove white spaces for PR

* remove white spaces for PR in interval machine

* remove white space in jones chain machine for PR

* remove white spaces for PR in madmax/plots

* remove white spaces in main.py for PR

* rename robust flagging variable for PR

* rename robust flag variable for PR

* rename variable robust flag disable for PR

* rename robust flag variable for PR

* remove white space for PR

* remove white spaces for PR

* fixed the conflict with define chunk line for PR

* Update ms_tile.py

* Update ms_tile.py

* Update interval_gain_machine.py

* Update interval_gain_machine.py

* Update interval_gain_machine.py

* Update jones_chain_robust_machine.py

* Update setup.py

* Update jones_chain_machine.py

* Update plots.py

* Update plots.py

Co-authored-by: Oleg Smirnov <osmirnov@gmail.com>
Co-authored-by: Ulrich Armel Mbou Sob <ulrich@jake.ru.ac.za>
Co-authored-by: Benjamin Hugo <bennahugo@aol.com>
Co-authored-by: Jonathan Kenyon <jskenyon007@gmail.com>
Co-authored-by: Jonathan Kenyon <jonosken@gmail.com>
Co-authored-by: JSKenyon <jonathan.simon.kenyon@gmail.com>